### PR TITLE
chore: update Docker image to v1.0.1 with Discord notifier support

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -4,5 +4,5 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 images:
 - name: controller
-  newName: controller
-  newTag: latest
+  newName: licioustech/endpoint-monitoring-operator
+  newTag: 1.0.1

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -423,7 +423,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: tarun4licious/endpoint-monitoring-operator:1.0.0
+        image: licioustech/endpoint-monitoring-operator:1.0.1
         livenessProbe:
           httpGet:
             path: /healthz


### PR DESCRIPTION
- Update image from tarun4licious to licioustech registry
- Bump version from 1.0.0 to 1.0.1
- Includes Discord notifier feature from PR #6