### PR TITLE
Decouple probe execution from reconciler with background scheduler

### DIFF
--- a/api/v1alpha1/endpointmonitor_types.go
+++ b/api/v1alpha1/endpointmonitor_types.go
@@ -55,8 +55,11 @@ type DiscordConfig struct {
 
 // EndpointMonitorStatus defines the observed state of EndpointMonitor
 type EndpointMonitorStatus struct {
-	LastCheckedTime metav1.Time `json:"lastCheckedTime,omitempty"`
-	LastStatus      string      `json:"lastStatus,omitempty"` // e.g., success/failure
+	LastCheckedTime   metav1.Time `json:"lastCheckedTime,omitempty"`
+	LastStatus        string      `json:"lastStatus,omitempty"` // e.g., success/failure
+	LastLatencyMillis int64       `json:"lastLatencyMillis,omitempty"`
+	LastStatusCode    int         `json:"lastStatusCode,omitempty"`
+	LastErrorMessage  string      `json:"lastErrorMessage,omitempty"`
 }
 
 //+kubebuilder:object:root=true

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -39,6 +39,8 @@ import (
 
 	monitoringv1alpha1 "github.com/LiciousTech/endpoint-monitoring-operator/api/v1alpha1"
 	"github.com/LiciousTech/endpoint-monitoring-operator/internal/controller"
+	"github.com/LiciousTech/endpoint-monitoring-operator/internal/scheduler"
+	"github.com/LiciousTech/endpoint-monitoring-operator/pkg/factory"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -202,9 +204,21 @@ func main() {
 		os.Exit(1)
 	}
 
+	probeScheduler := scheduler.New(
+		scheduler.Config{Workers: 20},
+		&factory.DriverFactory{},
+		&factory.NotifierFactory{},
+		scheduler.NewEndpointMonitorStatusWriter(mgr.GetClient()),
+	)
+	if err := mgr.Add(probeScheduler); err != nil {
+		setupLog.Error(err, "unable to add probe scheduler")
+		os.Exit(1)
+	}
+
 	if err = (&controller.EndpointMonitorReconciler{
-		Client: mgr.GetClient(),
-		Scheme: mgr.GetScheme(),
+		Client:    mgr.GetClient(),
+		Scheme:    mgr.GetScheme(),
+		Scheduler: probeScheduler,
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "EndpointMonitor")
 		os.Exit(1)

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -65,6 +65,7 @@ func main() {
 	var probeAddr string
 	var secureMetrics bool
 	var enableHTTP2 bool
+	var probeWorkers int
 	var tlsOpts []func(*tls.Config)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")
@@ -83,6 +84,7 @@ func main() {
 	flag.StringVar(&metricsCertKey, "metrics-cert-key", "tls.key", "The name of the metrics server key file.")
 	flag.BoolVar(&enableHTTP2, "enable-http2", false,
 		"If set, HTTP/2 will be enabled for the metrics and webhook servers")
+	flag.IntVar(&probeWorkers, "probe-workers", 20, "Number of concurrent probe workers")
 	opts := zap.Options{
 		Development: true,
 	}
@@ -205,7 +207,7 @@ func main() {
 	}
 
 	probeScheduler := scheduler.New(
-		scheduler.Config{Workers: 20},
+		scheduler.Config{Workers: probeWorkers},
 		&factory.DriverFactory{},
 		&factory.NotifierFactory{},
 		scheduler.NewEndpointMonitorStatusWriter(mgr.GetClient()),

--- a/config/crd/bases/monitoring.licious.app_endpointmonitors.yaml
+++ b/config/crd/bases/monitoring.licious.app_endpointmonitors.yaml
@@ -130,8 +130,15 @@ spec:
               lastCheckedTime:
                 format: date-time
                 type: string
+              lastErrorMessage:
+                type: string
+              lastLatencyMillis:
+                format: int64
+                type: integer
               lastStatus:
                 type: string
+              lastStatusCode:
+                type: integer
             type: object
         type: object
     served: true

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -138,8 +138,15 @@ spec:
               lastCheckedTime:
                 format: date-time
                 type: string
+              lastErrorMessage:
+                type: string
+              lastLatencyMillis:
+                format: int64
+                type: integer
               lastStatus:
                 type: string
+              lastStatusCode:
+                type: integer
             type: object
         type: object
     served: true

--- a/internal/controller/endpoint_controller_test.go
+++ b/internal/controller/endpoint_controller_test.go
@@ -30,6 +30,13 @@ import (
 	Endpointmonitoringv1alpha1 "github.com/LiciousTech/endpoint-monitoring-operator/api/v1alpha1"
 )
 
+type fakeScheduler struct{}
+
+func (f *fakeScheduler) Upsert(types.NamespacedName, Endpointmonitoringv1alpha1.EndpointMonitorSpec) {
+}
+func (f *fakeScheduler) Delete(types.NamespacedName) {}
+func (f *fakeScheduler) Start(context.Context) error { return nil }
+
 var _ = Describe("EndpointMonitor Controller", func() {
 	Context("When reconciling a resource", func() {
 		const resourceName = "test-resource"
@@ -51,14 +58,17 @@ var _ = Describe("EndpointMonitor Controller", func() {
 						Name:      resourceName,
 						Namespace: "default",
 					},
-					// TODO(user): Specify other spec details if needed.
+					Spec: Endpointmonitoringv1alpha1.EndpointMonitorSpec{
+						Driver:        "http",
+						Endpoint:      "https://example.com",
+						CheckInterval: 30,
+					},
 				}
 				Expect(k8sClient.Create(ctx, resource)).To(Succeed())
 			}
 		})
 
 		AfterEach(func() {
-			// TODO(user): Cleanup logic after each test, like removing the resource instance.
 			resource := &Endpointmonitoringv1alpha1.EndpointMonitor{}
 			err := k8sClient.Get(ctx, typeNamespacedName, resource)
 			Expect(err).NotTo(HaveOccurred())
@@ -69,16 +79,15 @@ var _ = Describe("EndpointMonitor Controller", func() {
 		It("should successfully reconcile the resource", func() {
 			By("Reconciling the created resource")
 			controllerReconciler := &EndpointMonitorReconciler{
-				Client: k8sClient,
-				Scheme: k8sClient.Scheme(),
+				Client:    k8sClient,
+				Scheme:    k8sClient.Scheme(),
+				Scheduler: &fakeScheduler{},
 			}
 
 			_, err := controllerReconciler.Reconcile(ctx, reconcile.Request{
 				NamespacedName: typeNamespacedName,
 			})
 			Expect(err).NotTo(HaveOccurred())
-			// TODO(user): Add more specific assertions depending on your controller's reconciliation logic.
-			// Example: If you expect a certain status condition after reconciliation, verify it here.
 		})
 	})
 })

--- a/internal/controller/endpointmonitor_controller.go
+++ b/internal/controller/endpointmonitor_controller.go
@@ -2,115 +2,55 @@ package controller
 
 import (
 	"context"
-	"fmt"
-	"time"
 
-	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	monitorv1alpha1 "github.com/LiciousTech/endpoint-monitoring-operator/api/v1alpha1"
-	"github.com/LiciousTech/endpoint-monitoring-operator/pkg/factory"
+	"github.com/LiciousTech/endpoint-monitoring-operator/internal/scheduler"
 )
+
+const probeCleanupFinalizer = "monitoring.licious.app/probe-cleanup"
 
 type EndpointMonitorReconciler struct {
 	client.Client
-	Scheme *runtime.Scheme
+	Scheme    *runtime.Scheme
+	Scheduler scheduler.ProbeScheduler
 }
 
 func (r *EndpointMonitorReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
-	logger := log.FromContext(ctx)
-
-	logger.Info("Reconcile triggered",
-		"name", req.Name,
-		"namespace", req.Namespace,
-		"timestamp", time.Now().Format(time.RFC3339))
-
 	var monitor monitorv1alpha1.EndpointMonitor
 	if err := r.Get(ctx, req.NamespacedName, &monitor); err != nil {
-		if errors.IsNotFound(err) {
-			logger.Info("EndpointMonitor resource not found. Ignoring since object must be deleted.")
+		if apierrors.IsNotFound(err) {
+			r.Scheduler.Delete(req.NamespacedName)
 			return ctrl.Result{}, nil
 		}
-		logger.Error(err, "Failed to get EndpointMonitor")
 		return ctrl.Result{}, err
 	}
 
-	now := time.Now()
-	checkInterval := time.Duration(monitor.Spec.CheckInterval) * time.Second
-	nextCheckTime := monitor.Status.LastCheckedTime.Time.Add(checkInterval)
-
-	if !monitor.Status.LastCheckedTime.IsZero() && now.Before(nextCheckTime) {
-		requeueAfter := time.Until(nextCheckTime)
-		logger.Info("Skipping reconcile; checkInterval not yet elapsed",
-			"name", monitor.Name,
-			"lastChecked", monitor.Status.LastCheckedTime.Time,
-			"nextCheckDue", nextCheckTime,
-			"requeueAfter", requeueAfter)
-		return ctrl.Result{RequeueAfter: requeueAfter}, nil
+	if monitor.DeletionTimestamp.IsZero() {
+		if !controllerutil.ContainsFinalizer(&monitor, probeCleanupFinalizer) {
+			controllerutil.AddFinalizer(&monitor, probeCleanupFinalizer)
+			if err := r.Update(ctx, &monitor); err != nil {
+				return ctrl.Result{}, err
+			}
+		}
+		r.Scheduler.Upsert(req.NamespacedName, monitor.Spec)
+		return ctrl.Result{}, nil
 	}
 
-	driver, err := factory.NewDriver(monitor.Spec.Driver, monitor.Spec.Endpoint, &monitor)
-	if err != nil {
-		logger.Error(err, "Failed to create driver")
-		return ctrl.Result{}, err
-	}
-
-	notifier, err := factory.NewNotifier(&monitor.Spec.Notify)
-	if err != nil {
-		logger.Error(err, "Failed to create notifier")
-		return ctrl.Result{}, err
-	}
-
-	result, err := driver.Check()
-	if err != nil {
-		logger.Error(err, "Failed to perform health check")
-		return ctrl.Result{}, err
-	}
-
-	var alertMessage, status string
-	if result.Success {
-		status = "success"
-		alertMessage = fmt.Sprintf("%s monitor for %s is healthy\n%s",
-			driver.GetType(), driver.GetEndpoint(), result.Message)
-	} else {
-		status = "failure"
-		alertMessage = fmt.Sprintf("%s monitor for %s is unhealthy\n%s",
-			driver.GetType(), driver.GetEndpoint(), result.Message)
-	}
-
-	if err := notifier.SendAlert(status, alertMessage); err != nil {
-		logger.Error(err, "Failed to send alert")
-		return ctrl.Result{}, err
-	}
-
-	updated := false
-	nowMetaTime := metav1.NewTime(now)
-	if monitor.Status.LastStatus != status {
-		monitor.Status.LastStatus = status
-		updated = true
-	}
-	if monitor.Status.LastCheckedTime != nowMetaTime {
-		monitor.Status.LastCheckedTime = nowMetaTime
-		updated = true
-	}
-
-	if updated {
-		if err := r.Status().Update(ctx, &monitor); err != nil {
-			logger.Error(err, "Failed to update EndpointMonitor status")
+	r.Scheduler.Delete(req.NamespacedName)
+	if controllerutil.ContainsFinalizer(&monitor, probeCleanupFinalizer) {
+		controllerutil.RemoveFinalizer(&monitor, probeCleanupFinalizer)
+		if err := r.Update(ctx, &monitor); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
-	logger.Info("Reconciliation complete",
-		"name", monitor.Name,
-		"status", status,
-		"responseTime", result.ResponseTime.String())
-
-	return ctrl.Result{RequeueAfter: checkInterval}, nil
+	return ctrl.Result{}, nil
 }
 
 func (r *EndpointMonitorReconciler) SetupWithManager(mgr ctrl.Manager) error {

--- a/internal/driver/dns.go
+++ b/internal/driver/dns.go
@@ -31,6 +31,7 @@ func (d *DNSDriver) Check() (*CheckResult, error) {
 	if err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = fmt.Sprintf("DNS check failed: %v", err)
 		return result, nil
 	}

--- a/internal/driver/driver.go
+++ b/internal/driver/driver.go
@@ -2,15 +2,17 @@ package driver
 
 import "time"
 
-// CheckResult represents the result of a health check
+// CheckResult represents the result of a health check.
 type CheckResult struct {
 	Success      bool
 	ResponseTime time.Duration
+	StatusCode   int
 	Error        error
+	ErrorMessage string
 	Message      string
 }
 
-// Driver interface for different monitoring types
+// Driver interface for different monitoring types.
 type Driver interface {
 	Check() (*CheckResult, error)
 	GetEndpoint() string

--- a/internal/driver/http.go
+++ b/internal/driver/http.go
@@ -37,11 +37,13 @@ func (h *HTTPDriver) Check() (*CheckResult, error) {
 	if err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = fmt.Sprintf("HTTP check failed: %v", err)
 		return result, nil
 	}
 
 	defer resp.Body.Close()
+	result.StatusCode = resp.StatusCode
 
 	if resp.StatusCode >= 200 && resp.StatusCode < 300 {
 		result.Success = true

--- a/internal/driver/httpjson.go
+++ b/internal/driver/httpjson.go
@@ -41,15 +41,18 @@ func (h *HTTPJSONDriver) Check() (*CheckResult, error) {
 	if err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = fmt.Sprintf("HTTP-JSON request failed: %v", err)
 		return result, nil
 	}
 	defer resp.Body.Close()
+	result.StatusCode = resp.StatusCode
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = "failed to read HTTP response body"
 		return result, nil
 	}
@@ -58,6 +61,7 @@ func (h *HTTPJSONDriver) Check() (*CheckResult, error) {
 	if err := json.Unmarshal(body, &payload); err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = "invalid JSON response"
 		return result, nil
 	}

--- a/internal/driver/opensearch.go
+++ b/internal/driver/opensearch.go
@@ -61,11 +61,13 @@ func (o *OpenSearchDriver) Check() (*CheckResult, error) {
 	if err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = fmt.Sprintf("OpenSearch check failed: %v", err)
 		return result, nil
 	}
 
 	defer resp.Body.Close()
+	result.StatusCode = resp.StatusCode
 
 	if resp.StatusCode != 200 {
 		result.Success = false
@@ -77,6 +79,7 @@ func (o *OpenSearchDriver) Check() (*CheckResult, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&health); err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = fmt.Sprintf("OpenSearch check failed to parse response: %v", err)
 		return result, nil
 	}

--- a/internal/driver/ping.go
+++ b/internal/driver/ping.go
@@ -32,6 +32,7 @@ func (p *PingDriver) Check() (*CheckResult, error) {
 	if err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = fmt.Sprintf("Ping check failed: %v", err)
 		return result, nil
 	}

--- a/internal/driver/tcp.go
+++ b/internal/driver/tcp.go
@@ -31,6 +31,7 @@ func (t *TCPDriver) Check() (*CheckResult, error) {
 	if err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = fmt.Sprintf("TCP check failed: %v", err)
 		return result, nil
 	}

--- a/internal/driver/trino.go
+++ b/internal/driver/trino.go
@@ -55,11 +55,13 @@ func (t *TrinoDriver) Check() (*CheckResult, error) {
 	if err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = fmt.Sprintf("Trino check failed: %v", err)
 		return result, nil
 	}
 
 	defer resp.Body.Close()
+	result.StatusCode = resp.StatusCode
 
 	if resp.StatusCode != 200 {
 		result.Success = false
@@ -71,6 +73,7 @@ func (t *TrinoDriver) Check() (*CheckResult, error) {
 	if err := json.NewDecoder(resp.Body).Decode(&trinoInfo); err != nil {
 		result.Success = false
 		result.Error = err
+		result.ErrorMessage = err.Error()
 		result.Message = fmt.Sprintf("Trino check failed to parse response: %v", err)
 		return result, nil
 	}

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"hash/fnv"
+	"sort"
 	"sync"
 	"time"
 
@@ -243,7 +244,25 @@ func (s *Scheduler) runJob(ctx context.Context, workerID int, job ProbeJob) {
 
 	checkResult, err := job.Driver.Check()
 	if err != nil {
-		checkResult = &driver.CheckResult{Success: false, Error: err, Message: err.Error()}
+		checkResult = &driver.CheckResult{Success: false, Error: err, ErrorMessage: err.Error(), Message: err.Error()}
+	}
+	if checkResult == nil {
+		checkResult = &driver.CheckResult{Success: false, ErrorMessage: "driver returned no result", Message: "driver returned no result"}
+	}
+
+	probeResult := ProbeResult{
+		Success:      checkResult.Success,
+		Latency:      checkResult.ResponseTime,
+		StatusCode:   checkResult.StatusCode,
+		ErrorMessage: checkResult.ErrorMessage,
+		CheckedAt:    metav1.Now(),
+	}
+	if probeResult.ErrorMessage == "" && checkResult.Error != nil {
+		probeResult.ErrorMessage = checkResult.Error.Error()
+	}
+
+	if err := job.Status.Write(ctx, job.Key, probeResult); err != nil {
+		logger.Error(err, "failed to write probe status")
 	}
 
 	status := "failure"
@@ -255,19 +274,11 @@ func (s *Scheduler) runJob(ctx context.Context, workerID int, job ProbeJob) {
 	if notifyErr := job.Notifier.SendAlert(status, message); notifyErr != nil {
 		logger.Error(notifyErr, "failed to notify")
 	}
-
-	probeResult := ProbeResult{Success: checkResult.Success, Latency: checkResult.ResponseTime, CheckedAt: metav1.Now()}
-	if checkResult.Error != nil {
-		probeResult.ErrorMessage = checkResult.Error.Error()
-	}
-
-	if err := job.Status.Write(ctx, job.Key, probeResult); err != nil {
-		logger.Error(err, "failed to write probe status")
-	}
 }
 
 func hashSpec(spec monitoringv1alpha1.EndpointMonitorSpec) (uint64, error) {
-	b, err := json.Marshal(spec)
+	normalized := normalizeSpecForHash(spec)
+	b, err := json.Marshal(normalized)
 	if err != nil {
 		return 0, err
 	}
@@ -276,4 +287,50 @@ func hashSpec(spec monitoringv1alpha1.EndpointMonitorSpec) (uint64, error) {
 		return 0, err
 	}
 	return h.Sum64(), nil
+}
+
+type hashSpecModel struct {
+	Driver        string            `json:"driver"`
+	Endpoint      string            `json:"endpoint"`
+	CheckInterval int               `json:"checkInterval"`
+	Notify        any               `json:"notify"`
+	HTTPJSON      *hashHTTPJSONSpec `json:"httpJsonCheck,omitempty"`
+}
+
+type hashHTTPJSONSpec struct {
+	ExpectedStatusCode int                 `json:"expectedStatusCode,omitempty"`
+	JsonAssertions     []hashAssertionItem `json:"jsonAssertions"`
+}
+
+type hashAssertionItem struct {
+	Key   string `json:"key"`
+	Value string `json:"value"`
+}
+
+func normalizeSpecForHash(spec monitoringv1alpha1.EndpointMonitorSpec) hashSpecModel {
+	normalized := hashSpecModel{
+		Driver:        spec.Driver,
+		Endpoint:      spec.Endpoint,
+		CheckInterval: spec.CheckInterval,
+		Notify:        spec.Notify,
+	}
+
+	if spec.HttpJsonCheck == nil {
+		return normalized
+	}
+
+	assertions := make([]hashAssertionItem, 0, len(spec.HttpJsonCheck.JsonAssertions))
+	for k, v := range spec.HttpJsonCheck.JsonAssertions {
+		assertions = append(assertions, hashAssertionItem{Key: k, Value: v})
+	}
+	sort.Slice(assertions, func(i, j int) bool {
+		return assertions[i].Key < assertions[j].Key
+	})
+
+	normalized.HTTPJSON = &hashHTTPJSONSpec{
+		ExpectedStatusCode: spec.HttpJsonCheck.ExpectedStatusCode,
+		JsonAssertions:     assertions,
+	}
+
+	return normalized
 }

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,279 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"hash/fnv"
+	"sync"
+	"time"
+
+	"github.com/go-logr/logr"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/clock"
+	ctrl "sigs.k8s.io/controller-runtime"
+
+	monitoringv1alpha1 "github.com/LiciousTech/endpoint-monitoring-operator/api/v1alpha1"
+	"github.com/LiciousTech/endpoint-monitoring-operator/internal/driver"
+	"github.com/LiciousTech/endpoint-monitoring-operator/internal/notifier"
+)
+
+const defaultWorkers = 20
+
+// DriverFactory creates a monitoring driver for a monitor spec.
+type DriverFactory interface {
+	CreateDriver(driverType string, endpoint string, monitor *monitoringv1alpha1.EndpointMonitor) (driver.Driver, error)
+}
+
+// NotifierFactory creates a notifier for a monitor spec.
+type NotifierFactory interface {
+	CreateNotifier(config *monitoringv1alpha1.NotifyConfig) (notifier.Notifier, error)
+}
+
+// ProbeResult contains the persisted result for a probe execution.
+type ProbeResult struct {
+	Success      bool
+	Latency      time.Duration
+	StatusCode   int
+	ErrorMessage string
+	CheckedAt    metav1.Time
+}
+
+// StatusWriter writes probe execution outcomes to EndpointMonitor status.
+type StatusWriter interface {
+	Write(ctx context.Context, key types.NamespacedName, result ProbeResult) error
+}
+
+// ProbeScheduler registers probes and manages background execution.
+type ProbeScheduler interface {
+	Upsert(key types.NamespacedName, spec monitoringv1alpha1.EndpointMonitorSpec)
+	Delete(key types.NamespacedName)
+	Start(ctx context.Context) error
+}
+
+// ProbeJob describes a single scheduled probe run.
+type ProbeJob struct {
+	Key      types.NamespacedName
+	Driver   driver.Driver
+	Notifier notifier.Notifier
+	Status   StatusWriter
+}
+
+// Config configures scheduler worker concurrency and queue size.
+type Config struct {
+	Workers   int
+	QueueSize int
+}
+
+type probeEntry struct {
+	spec   monitoringv1alpha1.EndpointMonitorSpec
+	hash   uint64
+	cancel context.CancelFunc
+	ticker clock.Ticker
+}
+
+// Scheduler runs timers and workers for all registered endpoint monitors.
+type Scheduler struct {
+	cfg             Config
+	driverFactory   DriverFactory
+	notifierFactory NotifierFactory
+	statusWriter    StatusWriter
+	clk             clock.WithTicker
+
+	mu      sync.Mutex
+	entries map[types.NamespacedName]*probeEntry
+	jobs    chan ProbeJob
+	logger  logr.Logger
+}
+
+// New creates a scheduler with defaults and production clock.
+func New(cfg Config, driverFactory DriverFactory, notifierFactory NotifierFactory, statusWriter StatusWriter) *Scheduler {
+	if cfg.Workers <= 0 {
+		cfg.Workers = defaultWorkers
+	}
+	if cfg.QueueSize <= 0 {
+		cfg.QueueSize = cfg.Workers * 4
+	}
+
+	return newWithClock(cfg, driverFactory, notifierFactory, statusWriter, clock.RealClock{})
+}
+
+func newWithClock(cfg Config, driverFactory DriverFactory, notifierFactory NotifierFactory, statusWriter StatusWriter, clk clock.WithTicker) *Scheduler {
+	return &Scheduler{
+		cfg:             cfg,
+		driverFactory:   driverFactory,
+		notifierFactory: notifierFactory,
+		statusWriter:    statusWriter,
+		clk:             clk,
+		entries:         make(map[types.NamespacedName]*probeEntry),
+		jobs:            make(chan ProbeJob, cfg.QueueSize),
+		logger:          ctrl.Log.WithName("probe-scheduler"),
+	}
+}
+
+// NeedLeaderElection indicates scheduler must run only on elected leader.
+func (s *Scheduler) NeedLeaderElection() bool {
+	return true
+}
+
+// Start runs worker pool until the manager context is canceled.
+func (s *Scheduler) Start(ctx context.Context) error {
+	var workers sync.WaitGroup
+	workers.Add(s.cfg.Workers)
+	for i := 0; i < s.cfg.Workers; i++ {
+		go func(workerID int) {
+			defer workers.Done()
+			s.workerLoop(ctx, workerID)
+		}(i)
+	}
+
+	<-ctx.Done()
+
+	s.mu.Lock()
+	for _, entry := range s.entries {
+		entry.cancel()
+		entry.ticker.Stop()
+	}
+	s.entries = map[types.NamespacedName]*probeEntry{}
+	s.mu.Unlock()
+
+	workers.Wait()
+	return nil
+}
+
+// Upsert registers or updates scheduling for a monitor key/spec.
+func (s *Scheduler) Upsert(key types.NamespacedName, spec monitoringv1alpha1.EndpointMonitorSpec) {
+	hash, err := hashSpec(spec)
+	if err != nil {
+		s.logger.Error(err, "unable to hash spec", "key", key)
+		return
+	}
+
+	interval := time.Duration(spec.CheckInterval) * time.Second
+	if interval <= 0 {
+		interval = time.Second
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if existing, ok := s.entries[key]; ok {
+		if existing.hash == hash {
+			return
+		}
+		existing.cancel()
+		existing.ticker.Stop()
+	}
+
+	probeCtx, cancel := context.WithCancel(context.Background())
+	ticker := s.clk.NewTicker(interval)
+	entry := &probeEntry{spec: spec, hash: hash, cancel: cancel, ticker: ticker}
+	s.entries[key] = entry
+
+	go s.dispatchProbeLoop(probeCtx, key, entry)
+}
+
+// Delete cancels and removes an existing scheduled monitor.
+func (s *Scheduler) Delete(key types.NamespacedName) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	entry, ok := s.entries[key]
+	if !ok {
+		return
+	}
+	entry.cancel()
+	entry.ticker.Stop()
+	delete(s.entries, key)
+}
+
+func (s *Scheduler) dispatchProbeLoop(ctx context.Context, key types.NamespacedName, entry *probeEntry) {
+	s.enqueueJob(key, entry.spec)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-entry.ticker.C():
+			s.enqueueJob(key, entry.spec)
+		}
+	}
+}
+
+func (s *Scheduler) enqueueJob(key types.NamespacedName, spec monitoringv1alpha1.EndpointMonitorSpec) {
+	monitor := &monitoringv1alpha1.EndpointMonitor{Spec: spec}
+	drv, err := s.driverFactory.CreateDriver(spec.Driver, spec.Endpoint, monitor)
+	if err != nil {
+		s.logger.Error(err, "unable to create driver", "key", key)
+		return
+	}
+
+	n, err := s.notifierFactory.CreateNotifier(&spec.Notify)
+	if err != nil {
+		s.logger.Error(err, "unable to create notifier", "key", key)
+		return
+	}
+
+	job := ProbeJob{Key: key, Driver: drv, Notifier: n, Status: s.statusWriter}
+
+	select {
+	case s.jobs <- job:
+	default:
+		s.logger.Info("dropping probe job because queue is full", "key", key)
+	}
+}
+
+func (s *Scheduler) workerLoop(ctx context.Context, workerID int) {
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case job := <-s.jobs:
+			s.runJob(ctx, workerID, job)
+		}
+	}
+}
+
+func (s *Scheduler) runJob(ctx context.Context, workerID int, job ProbeJob) {
+	logger := s.logger.WithValues("worker", workerID, "key", job.Key)
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			logger.Error(fmt.Errorf("panic: %v", recovered), "recovered panic in probe worker")
+		}
+	}()
+
+	checkResult, err := job.Driver.Check()
+	if err != nil {
+		checkResult = &driver.CheckResult{Success: false, Error: err, Message: err.Error()}
+	}
+
+	status := "failure"
+	if checkResult.Success {
+		status = "success"
+	}
+
+	message := fmt.Sprintf("%s monitor for %s: %s", job.Driver.GetType(), job.Driver.GetEndpoint(), checkResult.Message)
+	if notifyErr := job.Notifier.SendAlert(status, message); notifyErr != nil {
+		logger.Error(notifyErr, "failed to notify")
+	}
+
+	probeResult := ProbeResult{Success: checkResult.Success, Latency: checkResult.ResponseTime, CheckedAt: metav1.Now()}
+	if checkResult.Error != nil {
+		probeResult.ErrorMessage = checkResult.Error.Error()
+	}
+
+	if err := job.Status.Write(ctx, job.Key, probeResult); err != nil {
+		logger.Error(err, "failed to write probe status")
+	}
+}
+
+func hashSpec(spec monitoringv1alpha1.EndpointMonitorSpec) (uint64, error) {
+	b, err := json.Marshal(spec)
+	if err != nil {
+		return 0, err
+	}
+	h := fnv.New64a()
+	if _, err := h.Write(b); err != nil {
+		return 0, err
+	}
+	return h.Sum64(), nil
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,92 @@
+package scheduler
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	monitoringv1alpha1 "github.com/LiciousTech/endpoint-monitoring-operator/api/v1alpha1"
+	"github.com/LiciousTech/endpoint-monitoring-operator/internal/driver"
+	"github.com/LiciousTech/endpoint-monitoring-operator/internal/notifier"
+	"k8s.io/apimachinery/pkg/types"
+	clocktesting "k8s.io/utils/clock/testing"
+)
+
+type countingDriver struct {
+	key    string
+	counts *sync.Map
+}
+
+func (d *countingDriver) Check() (*driver.CheckResult, error) {
+	v, _ := d.counts.LoadOrStore(d.key, int64(0))
+	d.counts.Store(d.key, v.(int64)+1)
+	return &driver.CheckResult{Success: true, ResponseTime: 10 * time.Millisecond, Message: "ok"}, nil
+}
+func (d *countingDriver) GetEndpoint() string { return d.key }
+func (d *countingDriver) GetType() string     { return "mock" }
+
+type fakeDriverFactory struct{ counts *sync.Map }
+
+func (f *fakeDriverFactory) CreateDriver(_ string, endpoint string, _ *monitoringv1alpha1.EndpointMonitor) (driver.Driver, error) {
+	return &countingDriver{key: endpoint, counts: f.counts}, nil
+}
+
+type fakeNotifier struct{}
+
+func (f *fakeNotifier) SendAlert(string, string) error { return nil }
+
+type fakeNotifierFactory struct{}
+
+func (f *fakeNotifierFactory) CreateNotifier(_ *monitoringv1alpha1.NotifyConfig) (notifier.Notifier, error) {
+	return &fakeNotifier{}, nil
+}
+
+type fakeStatusWriter struct{}
+
+func (f *fakeStatusWriter) Write(context.Context, types.NamespacedName, ProbeResult) error {
+	return nil
+}
+
+func TestSchedulerRunsThreeProbesOnFakeClock(t *testing.T) {
+	fakeClock := clocktesting.NewFakeClock(time.Now())
+	counts := &sync.Map{}
+
+	s := newWithClock(
+		Config{Workers: 4, QueueSize: 100},
+		&fakeDriverFactory{counts: counts},
+		&fakeNotifierFactory{},
+		&fakeStatusWriter{},
+		fakeClock,
+	)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go func() { _ = s.Start(ctx) }()
+
+	interval := 2
+	for i := 0; i < 3; i++ {
+		key := types.NamespacedName{Name: "probe", Namespace: string(rune('a' + i))}
+		s.Upsert(key, monitoringv1alpha1.EndpointMonitorSpec{
+			Driver:        "http",
+			Endpoint:      key.Namespace,
+			CheckInterval: interval,
+			Notify:        monitoringv1alpha1.NotifyConfig{Slack: &monitoringv1alpha1.SlackConfig{Enabled: true, WebhookURL: "http://example"}},
+		})
+	}
+
+	fakeClock.Step(2 * time.Second)
+	time.Sleep(20 * time.Millisecond)
+	fakeClock.Step(2 * time.Second)
+	time.Sleep(20 * time.Millisecond)
+
+	for _, endpoint := range []string{"a", "b", "c"} {
+		v, ok := counts.Load(endpoint)
+		if !ok {
+			t.Fatalf("expected endpoint %s to be called", endpoint)
+		}
+		if v.(int64) < 2 {
+			t.Fatalf("expected endpoint %s to be called at least 2 times, got %d", endpoint, v.(int64))
+		}
+	}
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -2,6 +2,7 @@ package scheduler
 
 import (
 	"context"
+	"runtime"
 	"sync"
 	"testing"
 	"time"
@@ -21,7 +22,7 @@ type countingDriver struct {
 func (d *countingDriver) Check() (*driver.CheckResult, error) {
 	v, _ := d.counts.LoadOrStore(d.key, int64(0))
 	d.counts.Store(d.key, v.(int64)+1)
-	return &driver.CheckResult{Success: true, ResponseTime: 10 * time.Millisecond, Message: "ok"}, nil
+	return &driver.CheckResult{Success: true, ResponseTime: 10 * time.Millisecond, StatusCode: 200, Message: "ok"}, nil
 }
 func (d *countingDriver) GetEndpoint() string { return d.key }
 func (d *countingDriver) GetType() string     { return "mock" }
@@ -76,17 +77,27 @@ func TestSchedulerRunsThreeProbesOnFakeClock(t *testing.T) {
 	}
 
 	fakeClock.Step(2 * time.Second)
-	time.Sleep(20 * time.Millisecond)
 	fakeClock.Step(2 * time.Second)
-	time.Sleep(20 * time.Millisecond)
 
-	for _, endpoint := range []string{"a", "b", "c"} {
-		v, ok := counts.Load(endpoint)
-		if !ok {
-			t.Fatalf("expected endpoint %s to be called", endpoint)
+	waitFor(t, 2*time.Second, func() bool {
+		for _, endpoint := range []string{"a", "b", "c"} {
+			v, ok := counts.Load(endpoint)
+			if !ok || v.(int64) < 2 {
+				return false
+			}
 		}
-		if v.(int64) < 2 {
-			t.Fatalf("expected endpoint %s to be called at least 2 times, got %d", endpoint, v.(int64))
+		return true
+	})
+}
+
+func waitFor(t *testing.T, timeout time.Duration, fn func() bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		if fn() {
+			return
 		}
+		runtime.Gosched()
 	}
+	t.Fatalf("condition was not met before timeout %s", timeout)
 }

--- a/internal/scheduler/statuswriter.go
+++ b/internal/scheduler/statuswriter.go
@@ -1,0 +1,46 @@
+package scheduler
+
+import (
+	"context"
+	"encoding/json"
+
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	monitoringv1alpha1 "github.com/LiciousTech/endpoint-monitoring-operator/api/v1alpha1"
+)
+
+// EndpointMonitorStatusWriter patches EndpointMonitor status with probe results.
+type EndpointMonitorStatusWriter struct {
+	client client.Client
+}
+
+// NewEndpointMonitorStatusWriter creates a CR status writer implementation.
+func NewEndpointMonitorStatusWriter(c client.Client) *EndpointMonitorStatusWriter {
+	return &EndpointMonitorStatusWriter{client: c}
+}
+
+// Write patches the EndpointMonitor status for the given key.
+func (w *EndpointMonitorStatusWriter) Write(ctx context.Context, key types.NamespacedName, result ProbeResult) error {
+	status := map[string]any{
+		"lastCheckedTime":   result.CheckedAt,
+		"lastStatus":        "failure",
+		"lastLatencyMillis": result.Latency.Milliseconds(),
+		"lastStatusCode":    result.StatusCode,
+		"lastErrorMessage":  result.ErrorMessage,
+	}
+	if result.Success {
+		status["lastStatus"] = "success"
+	}
+
+	payload := map[string]any{"status": status}
+	patch, err := json.Marshal(payload)
+	if err != nil {
+		return err
+	}
+
+	obj := &monitoringv1alpha1.EndpointMonitor{}
+	obj.Name = key.Name
+	obj.Namespace = key.Namespace
+	return w.client.Status().Patch(ctx, obj, client.RawPatch(types.MergePatchType, patch))
+}

--- a/internal/scheduler/statuswriter.go
+++ b/internal/scheduler/statuswriter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
@@ -42,5 +43,12 @@ func (w *EndpointMonitorStatusWriter) Write(ctx context.Context, key types.Names
 	obj := &monitoringv1alpha1.EndpointMonitor{}
 	obj.Name = key.Name
 	obj.Namespace = key.Namespace
-	return w.client.Status().Patch(ctx, obj, client.RawPatch(types.MergePatchType, patch))
+	if err := w.client.Status().Patch(ctx, obj, client.RawPatch(types.MergePatchType, patch)); err != nil {
+		if apierrors.IsNotFound(err) {
+			return nil
+		}
+		return err
+	}
+
+	return nil
 }


### PR DESCRIPTION
### Motivation
- The reconciler previously executed probes inline and used `RequeueAfter`, which couples timing to controller-runtime queueing and causes queue flooding and interval drift at scale. 
- Probing needs a long-lived, leader-aware scheduler that owns timers and dispatches work to a bounded worker pool to improve reliability and scalability. 

### Description
- Added a new `internal/scheduler` package that implements a `ProbeScheduler` with `Upsert`, `Delete`, and `Start` semantics and a ticker-driven dispatch loop that enqueues `ProbeJob`s to a fixed worker pool. 
- Implemented idempotent `Upsert` using a deterministic FNV hash of the JSON-marshaled spec to avoid resetting timers when the spec is unchanged, and `Delete` to cancel and remove probe entries. 
- Workers consume jobs from a buffered channel, recover from panics, call `driver.Check()`, `notifier.SendAlert()`, and then write status via a `StatusWriter`; the scheduler exposes `NeedLeaderElection()` and `Start(ctx)` so it can be added to the manager lifecycle. 
- Added `internal/scheduler/statuswriter.go` to patch the CR status (status subresource) with `ProbeResult` fields (success, latency, status code, error message, checkedAt), and extended the CRD status (`api/v1alpha1/endpointmonitor_types.go`) to hold latency/status code/error message. 
- Refactored the reconciler (`internal/controller/endpointmonitor_controller.go`) to be a thin registration layer that manages a finalizer (`monitoring.licious.app/probe-cleanup`) and calls `Scheduler.Upsert`/`Delete` without `RequeueAfter`, and wired the scheduler into manager startup in `cmd/main.go`. 
- Added unit test `internal/scheduler/scheduler_test.go` which registers 3 probes with a mock driver and uses a fake clock to assert each probe executes the expected number of times. 

### Testing
- Ran `go test ./internal/scheduler -run TestSchedulerRunsThreeProbesOnFakeClock -count=1`, which passed. 
- Ran `go test ./cmd ./api/v1alpha1 ./pkg/factory -count=1`, which completed (no test files or no failures). 
- Ran `go test ./internal/controller -count=1`, which failed in this environment because controller-runtime `envtest` could not start the control plane due to missing kubebuilder/envtest binaries (e.g. `/usr/local/kubebuilder/bin/etcd`), so controller integration tests did not run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6fc744f20832fbdb9de4566857c1c)